### PR TITLE
ci: add missing directories to rockspec

### DIFF
--- a/.github/workflows/luarocks.yml
+++ b/.github/workflows/luarocks.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           crate: tree-sitter-cli
       - name: LuaRocks Upload
-        uses: nvim-neorocks/luarocks-tag-release@v7
+        uses: lumen-oss/luarocks-tag-release@v7
         env:
           LUAROCKS_API_KEY: ${{ secrets.LUAROCKS_API_KEY }}
         with:
@@ -30,3 +30,6 @@ jobs:
             coop.nvim
             tree-sitter-xml
             tree-sitter-html
+          copy_directories: |
+            {{ neovim.plugin.dirs }}
+            scripts


### PR DESCRIPTION
When feed.nvim is installed via luarocks, it's missing the files in "scripts/" which makes the call to
`vim.api.nvim_get_runtime_file("scripts/gfm.lua", false)[1]` fail with:

```

Lua :command callback: ...to/.local/share/nvim/rocks/rocks_rtp/lua/feed/pandoc.lua:41: invalid value (nil) at index 5 in table for 'concat'
stack traceback:
        [C]: in function 'concat'
        ...to/.local/share/nvim/rocks/rocks_rtp/lua/feed/pandoc.lua:41: in function 'convert'
        ...e/teto/.local/share/nvim/rocks/rocks_rtp/lua/feed/ui.lua:263: in function 'impl'
        .../.local/share/nvim/rocks/rocks_rtp/lua/feed/commands.lua:325: in function '_load_command'
        ...ib/luarocks/rocks-5.1/feed.nvim/2.19.1-1/plugin/feed.lua:34: in function <...ib/luarocks/rocks-5.1/feed.nvim/2.19.1-1/plugin/feed.lua:28>
```

The action org has been renamed as well so I updated its name.

I was not able to test if this fix solved https://github.com/neo451/feed.nvim/issues/212 since I could not think of a simple way to tell rocks.nvim to install from a local rockspec. But this seems like the correct thing to do anyway.